### PR TITLE
Add `Generic a => Generic (Identity a)` instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-foldable-traversable": "^2.0.0"
+    "purescript-foldable-traversable": "^2.0.0",
+    "purescript-generics": "^3.0.0"
   }
 }

--- a/src/Data/Identity.purs
+++ b/src/Data/Identity.purs
@@ -8,6 +8,7 @@ import Control.Extend (class Extend)
 
 import Data.Foldable (class Foldable)
 import Data.Functor.Invariant (class Invariant, imapF)
+import Data.Generic (class Generic)
 import Data.Monoid (class Monoid)
 import Data.Newtype (class Newtype)
 import Data.Traversable (class Traversable)
@@ -15,6 +16,8 @@ import Data.Traversable (class Traversable)
 newtype Identity a = Identity a
 
 derive instance newtypeIdentity :: Newtype (Identity a) _
+
+derive instance genericIdentity :: Generic a => Generic (Identity a)
 
 derive newtype instance eqIdentity :: Eq a => Eq (Identity a)
 


### PR DESCRIPTION
I'm not sure if this is the desired way to do this, or if we want to put this instance in purescript-generics, but one way or another, this instance deserves to exist _somewhere_.
