### PR TITLE
Fix Foldable1 Identity instance

### DIFF
--- a/src/Data/Identity.purs
+++ b/src/Data/Identity.purs
@@ -89,6 +89,8 @@ instance foldableIdentity :: Foldable Identity where
 instance foldable1Identity :: Foldable1 Identity where
   fold1 (Identity x) = x
   foldMap1 f (Identity x) = f x
+  foldl1 _ (Identity x) = x
+  foldr1 _ (Identity x) = x
 
 instance foldableWithIndexIdentity :: FoldableWithIndex Unit Identity where
   foldrWithIndex f z (Identity x) = f unit x z


### PR DESCRIPTION
Fixes build failures caused by the addition of `foldl1` and `foldr1`: https://github.com/purescript/purescript-foldable-traversable/pull/121