### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#20)
 
 New features:
+- This package no longer depends on the `purescript-foldable-traversable` package. Relevant instances have been moved to that package. (#26)
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
   ],
   "dependencies": {
     "purescript-control": "master",
-    "purescript-foldable-traversable": "master",
     "purescript-invariant": "master",
     "purescript-newtype": "master",
     "purescript-prelude": "master"

--- a/src/Data/Identity.purs
+++ b/src/Data/Identity.purs
@@ -7,16 +7,9 @@ import Control.Comonad (class Comonad)
 import Control.Extend (class Extend)
 import Control.Lazy (class Lazy)
 import Data.Eq (class Eq1)
-import Data.Foldable (class Foldable)
-import Data.FoldableWithIndex (class FoldableWithIndex)
 import Data.Functor.Invariant (class Invariant, imapF)
-import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Newtype (class Newtype)
 import Data.Ord (class Ord1)
-import Data.Semigroup.Foldable (class Foldable1)
-import Data.Semigroup.Traversable (class Traversable1)
-import Data.Traversable (class Traversable)
-import Data.TraversableWithIndex (class TraversableWithIndex)
 
 newtype Identity a = Identity a
 
@@ -55,9 +48,6 @@ derive instance ord1Identity :: Ord1 Identity
 
 derive instance functorIdentity :: Functor Identity
 
-instance functorWithIndexIdentity :: FunctorWithIndex Unit Identity where
-  mapWithIndex f (Identity a) = Identity (f unit a)
-
 instance invariantIdentity :: Invariant Identity where
   imap = imapF
 
@@ -80,29 +70,3 @@ instance extendIdentity :: Extend Identity where
 
 instance comonadIdentity :: Comonad Identity where
   extract (Identity x) = x
-
-instance foldableIdentity :: Foldable Identity where
-  foldr f z (Identity x) = f x z
-  foldl f z (Identity x) = f z x
-  foldMap f (Identity x) = f x
-
-instance foldable1Identity :: Foldable1 Identity where
-  foldMap1 f (Identity x) = f x
-  foldl1 _ (Identity x) = x
-  foldr1 _ (Identity x) = x
-
-instance foldableWithIndexIdentity :: FoldableWithIndex Unit Identity where
-  foldrWithIndex f z (Identity x) = f unit x z
-  foldlWithIndex f z (Identity x) = f unit z x
-  foldMapWithIndex f (Identity x) = f unit x
-
-instance traversableIdentity :: Traversable Identity where
-  traverse f (Identity x) = Identity <$> f x
-  sequence (Identity x) = Identity <$> x
-
-instance traversable1Identity :: Traversable1 Identity where
-  traverse1 f (Identity x) = Identity <$> f x
-  sequence1 (Identity x) = Identity <$> x
-
-instance traversableWithIndexIdentity :: TraversableWithIndex Unit Identity where
-  traverseWithIndex f (Identity x) = Identity <$> f unit x


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
