### PR TITLE
Fixing typo in Semigroup Identity instance name

### DIFF
--- a/src/Data/Identity.purs
+++ b/src/Data/Identity.purs
@@ -25,7 +25,7 @@ derive newtype instance heytingAlgebraIdentity :: HeytingAlgebra a => HeytingAlg
 
 derive newtype instance booleanAlgebraIdentity :: BooleanAlgebra a => BooleanAlgebra (Identity a)
 
-derive newtype instance semigroupIdenity :: Semigroup a => Semigroup (Identity a)
+derive newtype instance semigroupIdentity :: Semigroup a => Semigroup (Identity a)
 
 derive newtype instance monoidIdentity :: Monoid a => Monoid (Identity a)
 


### PR DESCRIPTION
**Description of the change**

The instance name of `Semigroup Identity` has a typo in it. This PR fixes the typo.

On a side note, I realize this suggestion has been made many times by many newcomers to PureScript, but let me use this opportunity to repeat it one more time: consider giving programmers the option of leaving out instance names and letting the compiler auto-generate them.

I want to note two things:

1) This typo in a core library has gone unnoticed for 6 years, and I only found it while browsing the source code (it didn't break anything I was working on). This suggests that instance names may not be that important.
2) Every single instance name in this file is equivalent to the concatenation of the types. If PureScript gave programmers the option of leaving out the instance name, all of the instance names in this file could have been left out and this typo would never have occurred.

IMHO, it seems like the main objections to auto-generation (ugly names, conflicts) make more sense as objections to *mandatory* auto-generation, but I don't think anyone is asking for that. People just want the *option* to leave out instance names when it's clear that the name is identical to a concatenation of the capitalized types, like all of the instances in this file.

It seems like the fear is that library authors will rely on auto-generation when they shouldn't, leading to libraries with poor JS interoperability, but any library can be written badly, and that's why we have Pull Requests and forks: to fix poor decisions. (Also, this doesn't prevent the library maintainers from choosing really bad instance names!)

Anyway, just my 2 cents.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
